### PR TITLE
add hash to the exercise id

### DIFF
--- a/src/handout_exercises/exercise.py
+++ b/src/handout_exercises/exercise.py
@@ -7,7 +7,7 @@ from urllib.parse import quote_plus
 import yaml
 import json
 import os.path as osp
-
+import re
 
 EXTRA_GROUP = 'extra'
 HANDOUT_GROUP = 'handout'
@@ -143,8 +143,13 @@ def find_exercises_in_handout(html, page_url, abs_path, code_exercises_by_path):
 
     soup = BeautifulSoup(html, 'html.parser')
     page_slug = page_url.replace('/', '-')
+    if page_slug == '':
+        page_slug = 'main-'
+
     for idx, ex in enumerate(soup.select('.admonition.exercise')):
         slug = str(idx)
+        slug = slug + '-' + str(hash(re.sub(r"[\n\t\s]*", "", ex.text)))
+
         for c in ex['class']:
             if c.startswith('id_'):
                 slug = c[3:]


### PR DESCRIPTION
oi pessoal,

eu adicionei um hash ao ID de cada admonition calculado a partir do texto de cada exercício, a ideia é que se o exercício mudar de lugar conseguimos rastrear ele (o texto não pode mudar...).

Pensei aqui se o ideal não seria tirar o contador do ID... o que acham?

nesse PR:

```
navigation-Labs-Lab_DRIVER-Lab-PIO-DRIVER-0-5916293777183651896
navigation-Labs-Lab_DRIVER-Lab-PIO-DRIVER-1--5567727536180463077
...
navigation-Labs-Lab_PIO_IRQ-Lab-PIO-IRQ-pratica-0--4829830919059178982
navigation-Labs-Lab_PIO_IRQ-Lab-PIO-IRQ-pratica-1-2261931260780979184
```

Sugestão removendo o `contador`: `navigation-Labs-Lab_PIO_IRQ-Lab-PIO-IRQ-pratica-2261931260780979184`

Aproveitei e adicionei o `main` como `page_slug` da página principal, caso contrário ele fica com ` `.