### PR TITLE
add table style

### DIFF
--- a/src/active_handout_theme/assets/css/main.css
+++ b/src/active_handout_theme/assets/css/main.css
@@ -1990,4 +1990,19 @@ section.progress-section:first-child, section.progress-section.show {
   display: inline;
 }
 
+table{
+  table-layout: fixed;
+  padding: 2rem;
+  border-collapse:collapse;
+}
+
+ th, td {
+  padding: 1rem;
+  border-bottom: .1rem solid var(--clr-gray-primary-3);
+}
+
+thead {
+  border-bottom: .3rem solid var(--clr-gray-primary-5);
+}
+
 /*# sourceMappingURL=main.css.map */


### PR DESCRIPTION
fix #57 

i think we need to add a space between table and other elements, but I couldn't find yet a way to do.. 

several uses:

![image](https://user-images.githubusercontent.com/1039615/210665592-35278e8d-ead8-42d8-8570-d3952bd16f1f.png)

just one line:
![image](https://user-images.githubusercontent.com/1039615/210665644-277f58d7-9932-4d23-ae9a-3eb52f48a91c.png)

larger table
![image](https://user-images.githubusercontent.com/1039615/210665708-7832a164-3073-41f5-bbb6-45400428d521.png)

between text 
![image](https://user-images.githubusercontent.com/1039615/210665742-93837eae-a7a0-4a0d-9d98-f53f52faf2d6.png)
